### PR TITLE
Define Dex ConfigMap from struct and iterate over connectors

### DIFF
--- a/controllers/dexserver_controller.go
+++ b/controllers/dexserver_controller.go
@@ -519,6 +519,7 @@ type DexConfigYamlSpec struct {
 }
 
 func (r *DexServerReconciler) defineConfigMap(m *authv1alpha1.DexServer, ctx context.Context) *corev1.ConfigMap {
+	log := ctrllog.FromContext(ctx)
 	// var configMapData = make(map[string]string)
 	// configMapData["config.yaml"] = dexconfigdata
 	labels := map[string]string{
@@ -590,8 +591,11 @@ func (r *DexServerReconciler) defineConfigMap(m *authv1alpha1.DexServer, ctx con
 	configYamlData.StaticClents = append(configYamlData.StaticClents, newStaticClient)
 
 	// Get string representation of the dex config.yaml
-	configYaml, _ := yaml.Marshal(&configYamlData)
+	configYaml, err := yaml.Marshal(&configYamlData)
 	// TODO - handle yaml err	
+	if err != nil {
+		log.Info("Error! failed to marshal dex config.yaml")
+	}
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/dexserver_controller.go
+++ b/controllers/dexserver_controller.go
@@ -460,62 +460,62 @@ func (r *DexServerReconciler) defineServiceGrpc(m *authv1alpha1.DexServer) *core
 
 // Definition of types needed to construct the config map used by the Dex application
 type DexStorageConfigSpec struct {
-	InCluster      bool   `yaml:"inCluster,omitempty"`
+	InCluster bool `yaml:"inCluster,omitempty"`
 }
 
 type DexStorageSpec struct {
-	Type 		string					`yaml:"type,omitempty"`
-	Config      DexStorageConfigSpec  	`yaml:"config,omitempty"`
+	Type   string               `yaml:"type,omitempty"`
+	Config DexStorageConfigSpec `yaml:"config,omitempty"`
 }
 
 type DexWebSpec struct {
 	Http    string `yaml:"http,omitempty"`
 	Https   string `yaml:"https,omitempty"`
 	TlsCert string `yaml:"tlsCert,omitempty"`
-	TlsKey  string `yaml:"tlsKey,omitempty"`	
+	TlsKey  string `yaml:"tlsKey,omitempty"`
 }
 type DexGrpcSpec struct {
-	Addr        string 	`yaml:"addr,omitempty"`
-	TlsCert     string 	`yaml:"tlsCert,omitempty"`
-	TlsKey      string 	`yaml:"tlsKey,omitempty"`
-	TlsClientCA string 	`yaml:"tlsClientCA,omitempty"`
-	Reflection 	bool 	`yaml:"reflection,omitempty"`
+	Addr        string `yaml:"addr,omitempty"`
+	TlsCert     string `yaml:"tlsCert,omitempty"`
+	TlsKey      string `yaml:"tlsKey,omitempty"`
+	TlsClientCA string `yaml:"tlsClientCA,omitempty"`
+	Reflection  bool   `yaml:"reflection,omitempty"`
 }
 
 type DexConnectorConfigSpec struct {
-	ClientID        string      `yaml:"clientID,omitempty"`
-	ClientSecret	string		`yaml:"clientSecret,omitempty"`
-	RedirectURI		string 		`yaml:"redirectURI,omitempty"`
-	Org         	string		`yaml:"org,omitempty"`
+	ClientID     string `yaml:"clientID,omitempty"`
+	ClientSecret string `yaml:"clientSecret,omitempty"`
+	RedirectURI  string `yaml:"redirectURI,omitempty"`
+	Org          string `yaml:"org,omitempty"`
 }
 
 type DexConnectorSpec struct {
 	// +kubebuilder:validation:Enum=github;ldap
-	Type   	string					`yaml:"type,omitempty"`
-	Id     	string        			`yaml:"id,omitempty"`
-	Name	string 					`yaml:"name,omitempty"`	
-	Config 	DexConnectorConfigSpec	`yaml:"config,omitempty"`
+	Type   string                 `yaml:"type,omitempty"`
+	Id     string                 `yaml:"id,omitempty"`
+	Name   string                 `yaml:"name,omitempty"`
+	Config DexConnectorConfigSpec `yaml:"config,omitempty"`
 }
 
 type DexOauth2Spec struct {
-	SkipApprovalScreen    bool     `yaml:"skipApprovalScreen,omitempty"`
+	SkipApprovalScreen bool `yaml:"skipApprovalScreen,omitempty"`
 }
 type DexStaticClientsSpec struct {
-	Id     			string		`yaml:"id,omitempty"`
-	RedirectURIs 	[]string	`yaml:"redirectURIs,omitempty"`
-	Name     		string      `yaml:"name,omitempty"`
-	Secret     		string      `yaml:"secret,omitempty"`
+	Id           string   `yaml:"id,omitempty"`
+	RedirectURIs []string `yaml:"redirectURIs,omitempty"`
+	Name         string   `yaml:"name,omitempty"`
+	Secret       string   `yaml:"secret,omitempty"`
 }
 
 type DexConfigYamlSpec struct {
-	Issuer 				string					`yaml:"issuer,omitempty"`
-	Storage 			DexStorageSpec			`yaml:"storage,omitempty"`
-	Web					DexWebSpec 				`yaml:"web,omitempty"`
-	Grpc				DexGrpcSpec				`yaml:"grpc,omitempty"`
-	Connectors			[]DexConnectorSpec    	`yaml:"connectors,omitempty"`
-	Oauth2          	DexOauth2Spec         	`yaml:"oauth2,omitempty"`
-	StaticClents		[]DexStaticClientsSpec	`yaml:"staticClients,omitempty"`
-	EnablePasswordDB	bool                 	`yaml:"enablePasswordDBv,omitempty"`
+	Issuer           string                 `yaml:"issuer,omitempty"`
+	Storage          DexStorageSpec         `yaml:"storage,omitempty"`
+	Web              DexWebSpec             `yaml:"web,omitempty"`
+	Grpc             DexGrpcSpec            `yaml:"grpc,omitempty"`
+	Connectors       []DexConnectorSpec     `yaml:"connectors,omitempty"`
+	Oauth2           DexOauth2Spec          `yaml:"oauth2,omitempty"`
+	StaticClents     []DexStaticClientsSpec `yaml:"staticClients,omitempty"`
+	EnablePasswordDB bool                   `yaml:"enablePasswordDBv,omitempty"`
 }
 
 func (r *DexServerReconciler) defineConfigMap(m *authv1alpha1.DexServer, ctx context.Context) *corev1.ConfigMap {
@@ -528,34 +528,34 @@ func (r *DexServerReconciler) defineConfigMap(m *authv1alpha1.DexServer, ctx con
 	clientSecret := getClientSecretFromRef(m, r, ctx)
 
 	// Define config yaml data for Dex
-	configYamlData := DexConfigYamlSpec {
+	configYamlData := DexConfigYamlSpec{
 		Issuer: m.Spec.Issuer,
-		Storage: DexStorageSpec {
+		Storage: DexStorageSpec{
 			Type: "kubernetes",
-			Config: DexStorageConfigSpec {
+			Config: DexStorageConfigSpec{
 				InCluster: true,
 			},
 		},
 		Web: DexWebSpec{
-			Https: "0.0.0.0:5556",
+			Https:   "0.0.0.0:5556",
 			TlsCert: "/etc/dex/tls/tls.crt",
-			TlsKey: "/etc/dex/tls/tls.key",		
+			TlsKey:  "/etc/dex/tls/tls.key",
 		},
-		Grpc: DexGrpcSpec {
-			Addr: "0.0.0.0:5557",
-			TlsCert: "/etc/dex/mtls/tls.crt",
-			TlsKey: "/etc/dex/mtls/tls.key",
+		Grpc: DexGrpcSpec{
+			Addr:        "0.0.0.0:5557",
+			TlsCert:     "/etc/dex/mtls/tls.crt",
+			TlsKey:      "/etc/dex/mtls/tls.key",
 			TlsClientCA: "/etc/dex/mtls/ca.crt",
-			Reflection: true,	
+			Reflection:  true,
 		},
-		Oauth2: DexOauth2Spec {
+		Oauth2: DexOauth2Spec{
 			SkipApprovalScreen: true,
 		},
 		EnablePasswordDB: true,
 	}
 
-	// Loop through connectors defined in the Server CR to create the dex configuration for connectors
-    for _, connector := range m.Spec.Connectors {
+	// Iterate over connectors defined in the DexServer to create the dex configuration for connectors
+	for _, connector := range m.Spec.Connectors {
 		// Determine the connector type
 		var connectorType string
 		switch connector.Type {
@@ -566,35 +566,36 @@ func (r *DexServerReconciler) defineConfigMap(m *authv1alpha1.DexServer, ctx con
 		default:
 			connectorType = string(authv1alpha1.ConnectorTypeGitHub)
 		}
-				
-		newConnector := DexConnectorSpec {
+
+		newConnector := DexConnectorSpec{
 			Type: connectorType,
-			Id: connector.Id,
+			Id:   connector.Id,
 			Name: connector.Name,
 			Config: DexConnectorConfigSpec{
-				ClientID: connector.Config.ClientID,
+				ClientID:     connector.Config.ClientID,
 				ClientSecret: clientSecret,
-				RedirectURI: connector.Config.RedirectURI,
-				Org: "kubernetes",
+				RedirectURI:  connector.Config.RedirectURI,
+				Org:          "kubernetes",
 			},
 		}
 		configYamlData.Connectors = append(configYamlData.Connectors, newConnector)
-    }
+	}
 
 	// Define StaticClients
-	newStaticClient := DexStaticClientsSpec {
-		Id: "example-app",
+	newStaticClient := DexStaticClientsSpec{
+		Id:           "example-app",
 		RedirectURIs: []string{"http://127.0.0.1:5555/callback"},
-		Name: "Example App",
-		Secret: "another-client-secret",
+		Name:         "Example App",
+		Secret:       "another-client-secret",
 	}
 	configYamlData.StaticClents = append(configYamlData.StaticClents, newStaticClient)
 
 	// Get string representation of the dex config.yaml
 	configYaml, err := yaml.Marshal(&configYamlData)
-	// TODO - handle yaml err	
+
 	if err != nil {
 		log.Info("Error! failed to marshal dex config.yaml")
+		return nil
 	}
 
 	cm := &corev1.ConfigMap{

--- a/controllers/dexserver_controller.go
+++ b/controllers/dexserver_controller.go
@@ -515,7 +515,7 @@ type DexConfigYamlSpec struct {
 	Connectors       []DexConnectorSpec     `yaml:"connectors,omitempty"`
 	Oauth2           DexOauth2Spec          `yaml:"oauth2,omitempty"`
 	StaticClents     []DexStaticClientsSpec `yaml:"staticClients,omitempty"`
-	EnablePasswordDB bool                   `yaml:"enablePasswordDBv,omitempty"`
+	EnablePasswordDB bool                   `yaml:"enablePasswordDB,omitempty"`
 }
 
 func (r *DexServerReconciler) defineConfigMap(m *authv1alpha1.DexServer, ctx context.Context) *corev1.ConfigMap {
@@ -581,14 +581,15 @@ func (r *DexServerReconciler) defineConfigMap(m *authv1alpha1.DexServer, ctx con
 		configYamlData.Connectors = append(configYamlData.Connectors, newConnector)
 	}
 
+	// The following code can be uncommented if we need to use StaticClients
 	// Define StaticClients
-	newStaticClient := DexStaticClientsSpec{
-		Id:           "example-app",
-		RedirectURIs: []string{"http://127.0.0.1:5555/callback"},
-		Name:         "Example App",
-		Secret:       "another-client-secret",
-	}
-	configYamlData.StaticClents = append(configYamlData.StaticClents, newStaticClient)
+	// newStaticClient := DexStaticClientsSpec{
+	// 	Id:           "example-app",
+	// 	RedirectURIs: []string{"http://127.0.0.1:5555/callback"},
+	// 	Name:         "Example App",
+	// 	Secret:       "another-client-secret",
+	// }
+	// configYamlData.StaticClents = append(configYamlData.StaticClents, newStaticClient)
 
 	// Get yaml representation of configYamlData
 	configYaml, err := yaml.Marshal(&configYamlData)

--- a/controllers/dexserver_controller.go
+++ b/controllers/dexserver_controller.go
@@ -590,7 +590,7 @@ func (r *DexServerReconciler) defineConfigMap(m *authv1alpha1.DexServer, ctx con
 	}
 	configYamlData.StaticClents = append(configYamlData.StaticClents, newStaticClient)
 
-	// Get string representation of the dex config.yaml
+	// Get yaml representation of configYamlData
 	configYaml, err := yaml.Marshal(&configYamlData)
 
 	if err != nil {

--- a/controllers/dexserver_controller.go
+++ b/controllers/dexserver_controller.go
@@ -482,6 +482,8 @@ type DexGrpcSpec struct {
 	Reflection  bool   `yaml:"reflection,omitempty"`
 }
 
+// The DexConnectorConfigSpec is specific to the Github connector as of now 
+// TODO: Add config properties for ldap
 type DexConnectorConfigSpec struct {
 	ClientID     string `yaml:"clientID,omitempty"`
 	ClientSecret string `yaml:"clientSecret,omitempty"`
@@ -520,8 +522,7 @@ type DexConfigYamlSpec struct {
 
 func (r *DexServerReconciler) defineConfigMap(m *authv1alpha1.DexServer, ctx context.Context) *corev1.ConfigMap {
 	log := ctrllog.FromContext(ctx)
-	// var configMapData = make(map[string]string)
-	// configMapData["config.yaml"] = dexconfigdata
+
 	labels := map[string]string{
 		"app": m.Name,
 	}
@@ -571,7 +572,7 @@ func (r *DexServerReconciler) defineConfigMap(m *authv1alpha1.DexServer, ctx con
 			Type: connectorType,
 			Id:   connector.Id,
 			Name: connector.Name,
-			Config: DexConnectorConfigSpec{
+			Config: DexConnectorConfigSpec{	// This definition is specific to the Github connector (the ldap configuration has different attributes for config)
 				ClientID:     connector.Config.ClientID,
 				ClientSecret: clientSecret,
 				RedirectURI:  connector.Config.RedirectURI,

--- a/controllers/dexserver_controller.go
+++ b/controllers/dexserver_controller.go
@@ -474,6 +474,7 @@ type DexWebSpec struct {
 	TlsCert string `yaml:"tlsCert,omitempty"`
 	TlsKey  string `yaml:"tlsKey,omitempty"`
 }
+
 type DexGrpcSpec struct {
 	Addr        string `yaml:"addr,omitempty"`
 	TlsCert     string `yaml:"tlsCert,omitempty"`
@@ -502,6 +503,7 @@ type DexConnectorSpec struct {
 type DexOauth2Spec struct {
 	SkipApprovalScreen bool `yaml:"skipApprovalScreen,omitempty"`
 }
+
 type DexStaticClientsSpec struct {
 	Id           string   `yaml:"id,omitempty"`
 	RedirectURIs []string `yaml:"redirectURIs,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	google.golang.org/grpc v1.40.0
 	google.golang.org/protobuf v1.27.1
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/api v0.22.0
 	k8s.io/apiextensions-apiserver v0.22.0
 	k8s.io/apimachinery v0.22.0


### PR DESCRIPTION
- Define the config.yaml data for Dex using a struct rather than a string literal
- Iterate over connectors defined in DexServer to construct the connectors for the Dex config.yaml