### PR TITLE
Make the dex image configurable

### DIFF
--- a/Makefile2.mak
+++ b/Makefile2.mak
@@ -1,5 +1,15 @@
+DEX_IMAGE ?= "quay.io/dexidp/dex:v2.28.1"
+
+.PHONY: dex-image
+dex-image:
+	@echo ""
+	@echo "Using DEX_IMAGE: $(DEX_IMAGE)"
+	perl -pi -e "s#quay.io/dexidp/dex:v2.28.1#${DEX_IMAGE}#g" config/manager/manager.yaml
+
+
 .PHONY: bits
-bits: build manifests docker-build docker-push bundle bundle-build bundle-push
+bits: build dex-image manifests docker-build docker-push bundle bundle-build bundle-push
+
 
 .PHONY: sdk-run
 sdk-run:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This is a operator-sdk based operator to deploy and manage a Dex server instance
     export IMAGE_TAG_BASE=quay.io/cdoan/dex-operator
     # OPTIONAL: arbitrarly change the version number of the image and bundle.
     export VERSION=0.0.5
+    # OPTIONAL: specify an alternate dex server image
+    # export DEX_IMAGE=your.internal.registry.io/x/y:v0.0.0
 
     # build all the components
     make bits

--- a/bundle/manifests/dex-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dex-operator.clusterserviceversion.yaml
@@ -314,6 +314,9 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
+                env:
+                - name: RELATED_IMAGE_DEX
+                  value: quay.io/dexidp/dex:v2.28.1
                 image: quay.io/cdoan/dex-operator:0.0.4
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,9 @@ spec:
         - --leader-elect
         image: controller:latest
         imagePullPolicy: Always
+        env:
+        - name: RELATED_IMAGE_DEX
+          value: quay.io/dexidp/dex:v2.28.1
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Leverage an environment variable `RELATED_IMAGE_DEX` to specify dex image. This is required by the controller and defaults to quay.io/dexidp/dex:v2.28.1 in the bundle created in this repo. Devs can override by exporting `DEX_IMAGE` before running `make bits` as noted in the README.  