### PR TITLE
Update role in clusterrolebindings

### DIFF
--- a/api/v1alpha1/dexserver_types.go
+++ b/api/v1alpha1/dexserver_types.go
@@ -99,7 +99,7 @@ type MicrosoftConfigSpec struct {
 	ClientSecretRef corev1.SecretReference `json:"clientSecretRef,omitempty"`
 	RedirectURI     string                 `json:"redirectURI,omitempty"`
 	// groups claim in dex is only supported when tenant is specified in Microsoft connector config.
-	Tenant 			string 					`json:"tenant,omitempty"`
+	Tenant string `json:"tenant,omitempty"`
 	// When the groups claim is present in a request to dex and tenant is configured,
 	// dex will query Microsoft API to obtain a list of groups the user is a member of.
 	// onlySecurityGroups configuration option restricts the list to include only security groups.

--- a/bundle/manifests/dex-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dex-operator.clusterserviceversion.yaml
@@ -350,7 +350,7 @@ spec:
                 env:
                 - name: RELATED_IMAGE_DEX
                   value: quay.io/dexidp/dex:v2.28.1
-                image: quay.io/vnambiar/dex-operator:main
+                image: quay.io/vnambiar/dex-operator:role-update
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/bundle/manifests/dex-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dex-operator.clusterserviceversion.yaml
@@ -263,8 +263,11 @@ spec:
           - clusterrolebindings
           verbs:
           - create
+          - delete
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - rbac.authorization.k8s.io
@@ -347,7 +350,7 @@ spec:
                 env:
                 - name: RELATED_IMAGE_DEX
                   value: quay.io/dexidp/dex:v2.28.1
-                image: quay.io/vnambiar/dex-operator:add-ms
+                image: quay.io/vnambiar/dex-operator:main
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/vnambiar/dex-operator
-  newTag: main
+  newTag: role-update

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/vnambiar/dex-operator
-  newTag: add-ms
+  newTag: main

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -160,8 +160,11 @@ rules:
   - clusterrolebindings
   verbs:
   - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/controllers/dexserver_controller.go
+++ b/controllers/dexserver_controller.go
@@ -85,7 +85,7 @@ type DexServerReconciler struct {
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes/custom-host,verbs=create;patch
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources={clusterroles},verbs=get;list;watch;create;update;patch;delete;escalate;bind
-//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources={clusterrolebindings},verbs=get;list;create;watch
+//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources={clusterrolebindings},verbs=get;list;create;watch;update;patch;delete
 //+kubebuilder:rbac:groups="apiextensions.k8s.io",resources={customresourcedefinitions},verbs=get;list;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/status,verbs=get;update;patch


### PR DESCRIPTION
This should fix the following error that was preventing the DexServer from being set up 
```
2021-09-29T19:22:59.740Z	ERROR	controller-runtime.manager.controller.dexserver	failed to sync ClusterRoleBinding	{"reconciler group": "auth.identitatem.io", "reconciler kind": "DexServer", "name": "dex2", "namespace": "dex-operator", "error": "\"dex-server/cluster_role_binding.yaml\" (string): clusterrolebindings.rbac.authorization.k8s.io \"dex-operator-dexsso-dex-operator\" is forbidden: User \"system:serviceaccount:dex-operator:dex-operator-controller-manager\" cannot update resource \"clusterrolebindings\" in API group \"rbac.authorization.k8s.io\" at the cluster scope"}
```