### PR TITLE
support kubectl rollout restart of deployment and automatically restart on configmap changes

### DIFF
--- a/deploy/dex-server/deployment.yaml
+++ b/deploy/dex-server/deployment.yaml
@@ -12,6 +12,10 @@ spec:
       dexconfig_namespace: "{{ .DexServer.Namespace }}"
   template:
     metadata:
+      {{ if .DexConfigMapHash}}
+      annotations:
+        auth.identitatem.io/configHash: "{{ .DexConfigMapHash }}"
+      {{ end }}  
       labels:
         app: "{{ .DexServer.Name }}"
         dexconfig_name: "{{ .DexServer.Name }}"


### PR DESCRIPTION
Currently when you run an `oc rollout restart deployment dex2`, the rollout doesn't take because the annotation added by the command ("kubectl.kubernetes.io/restartedAt") ends up removed by the reconcile loop and the new replicaset is scaled to zero and the original replicaset is used. With this PR, we add a predicate to filter out updates to the deployment related to a restart.

In addition (second commit), the sha256 checksum of the configmap is added to the deployment to trigger restarts when the configmap changes.

Issue:https://github.com/open-cluster-management/backlog/issues/16516