### PR TITLE
recycle mtls cert for grpc when close to expiring

### DIFF
--- a/deploy/dex-server/deployment.yaml
+++ b/deploy/dex-server/deployment.yaml
@@ -12,10 +12,13 @@ spec:
       dexconfig_namespace: "{{ .DexServer.Namespace }}"
   template:
     metadata:
-      {{ if .DexConfigMapHash}}
       annotations:
+      {{ if .DexConfigMapHash}}
         auth.identitatem.io/configHash: "{{ .DexConfigMapHash }}"
-      {{ end }}  
+      {{ end }}
+      {{ if .MtlsSecretExpiry}}
+        auth.identitatem.io/grpcMtlsExpiry: "{{ .MtlsSecretExpiry }}" 
+      {{ end }}
       labels:
         app: "{{ .DexServer.Name }}"
         dexconfig_name: "{{ .DexServer.Name }}"


### PR DESCRIPTION
mtls certs expire after 24 hours. with this change, we will check to see if we are within two hours of expiring and if so regenerate the cert and restart the dex server.
Issue: https://github.com/open-cluster-management/backlog/issues/16826