### PR TITLE
Liveness and readiness probes for dex server deployment

### DIFF
--- a/deploy/dex-server/deployment.yaml
+++ b/deploy/dex-server/deployment.yaml
@@ -77,6 +77,16 @@ spec:
           name: tls
         - mountPath: /etc/dex/mtls
           name: mtls
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 5556
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 5556
+            scheme: HTTPS                    
 {{ .AdditionalVolumeMounts | indent 8 }}
       serviceAccountName: "{{ .ServiceAccountName }}"
       tolerations:


### PR DESCRIPTION
Zenhub issue: https://github.com/open-cluster-management/backlog/issues/17482