### PR TITLE
Hot fix for volumeMounts config in dex server deployment

### DIFF
--- a/deploy/dex-server/deployment.yaml
+++ b/deploy/dex-server/deployment.yaml
@@ -76,7 +76,8 @@ spec:
         - mountPath: /etc/dex/tls
           name: tls
         - mountPath: /etc/dex/mtls
-          name: mtls
+          name: mtls                  
+{{ .AdditionalVolumeMounts | indent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -86,8 +87,7 @@ spec:
           httpGet:
             path: /healthz
             port: 5556
-            scheme: HTTPS                    
-{{ .AdditionalVolumeMounts | indent 8 }}
+            scheme: HTTPS  
       serviceAccountName: "{{ .ServiceAccountName }}"
       tolerations:
         - key: node-role.kubernetes.io/infra


### PR DESCRIPTION
The `AdditionalVolumeMounts` variable needs to be right after the volumeMounts for dex.