### PR TITLE
bump default dex to 2.30.2

### DIFF
--- a/Makefile2.mak
+++ b/Makefile2.mak
@@ -1,10 +1,10 @@
-DEX_IMAGE ?= "quay.io/dexidp/dex:v2.28.1"
+DEX_IMAGE ?= "ghcr.io/dexidp/dex:v2.30.2"
 
 .PHONY: dex-image
 dex-image:
 	@echo ""
 	@echo "Using DEX_IMAGE: $(DEX_IMAGE)"
-	perl -pi -e "s#quay.io/dexidp/dex:v2.28.1#${DEX_IMAGE}#g" config/manager/manager.yaml
+	perl -pi -e "s#ghcr.io/dexidp/dex:v2.30.2#${DEX_IMAGE}#g" config/manager/manager.yaml
 
 
 .PHONY: run-local

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ oc apply -f hack/deployment.yaml
 
 ```bash
 oc new-project dex-operator
-export RELATED_IMAGE_DEX=quay.io/dexidp/dex:v2.28.1
+export RELATED_IMAGE_DEX=ghcr.io/dexidp/dex:v2.30.2
 make run-local
 ```
 
@@ -224,7 +224,7 @@ If you want to test using the VSCode debugger, you will need a .vscode/launch.js
             "mode": "debug",
             "program": "${workspaceFolder}/main.go",
             "env": {
-                "RELATED_IMAGE_DEX": "quay.io/dexidp/dex:v2.28.1"
+                "RELATED_IMAGE_DEX": "ghcr.io/dexidp/dex:v2.30.2"
             }
         }
 

--- a/api/v1alpha1/dexserver_types.go
+++ b/api/v1alpha1/dexserver_types.go
@@ -174,7 +174,7 @@ type DexServerSpec struct {
 
 const (
 	DexServerConditionTypeApplied string = "Applied"
-	DexServerDeploymentAvailable string = "Available"
+	DexServerDeploymentAvailable  string = "Available"
 )
 
 // DexServerStatus defines the observed state of DexServer

--- a/bundle/manifests/dex-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dex-operator.clusterserviceversion.yaml
@@ -349,7 +349,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_DEX
-                  value: quay.io/dexidp/dex:v2.28.1
+                  value: ghcr.io/dexidp/dex:v2.30.2
                 image: quay.io/vnambiar/dex-operator:dex-cl-secret
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,7 +55,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: RELATED_IMAGE_DEX
-              value: quay.io/dexidp/dex:v2.28.1
+              value: ghcr.io/dexidp/dex:v2.30.2
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/controllers/dexserver_controller.go
+++ b/controllers/dexserver_controller.go
@@ -267,7 +267,7 @@ func (r *DexServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 	if err := updateDexServerStatusConditions(r.Client, dexServer, cond); err != nil {
 		return ctrl.Result{}, err
-	}	
+	}
 
 	// Reconcile hourly to ensure grpc mtls certs are regenerated before expiry
 	return ctrl.Result{Requeue: true, RequeueAfter: 1 * time.Hour}, nil
@@ -301,7 +301,7 @@ func (r *DexServerReconciler) getDexServerDeploymentCondition(dexServer *authv1a
 			condition.Message += ", " + err.Error()
 			return condition, nil
 		}
-	
+
 		return condition, nil
 	}
 }


### PR DESCRIPTION
Bumping to 2.30.2 to support OCP 4.9 and up. 
See https://github.com/open-cluster-management/backlog/issues/17485
