### PR TITLE
Test suite for dex client controller

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+# Copyright Red Hat
+
+name: Test
+
+on: 
+  push:
+  pull_request:
+      branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16    
+
+    - name: Test
+      run: make test

--- a/controllers/dex/dex.go
+++ b/controllers/dex/dex.go
@@ -29,8 +29,8 @@ type Options struct {
 
 // APIClient represent a client wrapper for Dex
 type APIClient struct {
-	dex api.DexClient
-	cc  *grpc.ClientConn
+	Dex api.DexClient
+	Cc  *grpc.ClientConn
 }
 
 func NewClientPEM(opts *Options) (*APIClient, error) {
@@ -57,15 +57,15 @@ func NewClientPEM(opts *Options) (*APIClient, error) {
 		return nil, errors.Wrapf(err, "opening the gRPC connection with server %q", opts.HostAndPort)
 	}
 	return &APIClient{
-		dex: api.NewDexClient(conn),
-		cc:  conn,
+		Dex: api.NewDexClient(conn),
+		Cc:  conn,
 	}, nil
 }
 
 // GetServerInfo returns server info
 func (c *APIClient) GetServerInfo(ctx context.Context) (string, error) {
 	req := &api.VersionReq{}
-	res, err := c.dex.GetVersion(ctx, req)
+	res, err := c.Dex.GetVersion(ctx, req)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to to get DEX version")
 	}
@@ -96,7 +96,7 @@ func (c *APIClient) CreateClient(ctx context.Context, redirectUris []string, tru
 		},
 	}
 
-	res, err := c.dex.CreateClient(ctx, req)
+	res, err := c.Dex.CreateClient(ctx, req)
 	if err != nil {
 		return nil, &CreateClientError{errors.Wrap(err, "failed to create the OIDC client"), false}
 	}
@@ -118,7 +118,7 @@ func (c *APIClient) UpdateClient(ctx context.Context, clientID string, redirectU
 		Name:         name,
 		LogoUrl:      logoURL,
 	}
-	res, err := c.dex.UpdateClient(ctx, req)
+	res, err := c.Dex.UpdateClient(ctx, req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update the client with id %q", clientID)
 	}
@@ -134,7 +134,7 @@ func (c *APIClient) DeleteClient(ctx context.Context, id string) *DeleteClientEr
 	req := &api.DeleteClientReq{
 		Id: id,
 	}
-	res, err := c.dex.DeleteClient(ctx, req)
+	res, err := c.Dex.DeleteClient(ctx, req)
 	if err != nil {
 		return &DeleteClientError{errors.Wrapf(err, "failed to delete the client with id %q", id), false}
 	}
@@ -147,7 +147,7 @@ func (c *APIClient) DeleteClient(ctx context.Context, id string) *DeleteClientEr
 
 // CloseConnection calls Close on the ClientConn
 func (c *APIClient) CloseConnection() error {
-	err := c.cc.Close()
+	err := c.Cc.Close()
 	if err != nil {
 		return errors.Wrapf(err, "error occurred closing the connection")
 	}

--- a/controllers/dexclient_controller.go
+++ b/controllers/dexclient_controller.go
@@ -44,6 +44,8 @@ type DexClientReconciler struct {
 	Scheme *runtime.Scheme
 }
 
+var DexapiNewClientPEM = dexapi.NewClientPEM
+
 //+kubebuilder:rbac:groups=auth.identitatem.io,resources=dexclients,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=auth.identitatem.io,resources=dexclients/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=auth.identitatem.io,resources=dexclients/finalizers,verbs=update
@@ -137,7 +139,7 @@ func (r *DexClientReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		CrtBuffer:   bytes.NewBuffer(mTLSSecret.Data["client.crt"]),
 		KeyBuffer:   bytes.NewBuffer(mTLSSecret.Data["client.key"]),
 	}
-	dexApiClient, err := dexapi.NewClientPEM(dexApiOptions)
+	dexApiClient, err := DexapiNewClientPEM(dexApiOptions)
 	if err != nil {
 		log.Error(err, "Failed to create api client connection to gRPC server", "client", dexv1Client.Name)
 		cond := metav1.Condition{

--- a/controllers/dexclient_controller_test.go
+++ b/controllers/dexclient_controller_test.go
@@ -1,0 +1,264 @@
+// Copyright Red Hat
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	api "github.com/dexidp/dex/api/v2"
+	authv1alpha1 "github.com/identitatem/dex-operator/api/v1alpha1"
+	dexapi "github.com/identitatem/dex-operator/controllers/dex"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+/* Mock api.DexClient:
+This is so that we can override the implementation of CreateClient, UpdateClient and DeleteClient.
+Note: All the interface methods of api.DexClient need to be implemented by the mock so that we can use this mock
+to generate the api client that will be returned to the dex client controller.
+*/
+type MockDexAPIClient struct{}
+
+func (m *MockDexAPIClient) CreateClient(ctx context.Context, in *api.CreateClientReq, opts ...grpc.CallOption) (*api.CreateClientResp, error) {
+	client := &api.Client{
+		Id: "dex-client-id1",
+	}
+	return &api.CreateClientResp{
+		Client: client,
+	}, nil
+}
+func (m *MockDexAPIClient) UpdateClient(ctx context.Context, in *api.UpdateClientReq, opts ...grpc.CallOption) (*api.UpdateClientResp, error) {
+	return &api.UpdateClientResp{}, nil
+}
+func (m *MockDexAPIClient) DeleteClient(ctx context.Context, in *api.DeleteClientReq, opts ...grpc.CallOption) (*api.DeleteClientResp, error) {
+	return &api.DeleteClientResp{}, nil
+}
+func (m *MockDexAPIClient) CreatePassword(ctx context.Context, in *api.CreatePasswordReq, opts ...grpc.CallOption) (*api.CreatePasswordResp, error) {
+	return nil, nil
+}
+func (m *MockDexAPIClient) UpdatePassword(ctx context.Context, in *api.UpdatePasswordReq, opts ...grpc.CallOption) (*api.UpdatePasswordResp, error) {
+	return nil, nil
+}
+func (m *MockDexAPIClient) DeletePassword(ctx context.Context, in *api.DeletePasswordReq, opts ...grpc.CallOption) (*api.DeletePasswordResp, error) {
+	return nil, nil
+}
+func (m *MockDexAPIClient) ListPasswords(ctx context.Context, in *api.ListPasswordReq, opts ...grpc.CallOption) (*api.ListPasswordResp, error) {
+	return nil, nil
+}
+func (m *MockDexAPIClient) GetVersion(ctx context.Context, in *api.VersionReq, opts ...grpc.CallOption) (*api.VersionResp, error) {
+	return nil, nil
+}
+func (m *MockDexAPIClient) ListRefresh(ctx context.Context, in *api.ListRefreshReq, opts ...grpc.CallOption) (*api.ListRefreshResp, error) {
+	return nil, nil
+}
+func (m *MockDexAPIClient) RevokeRefresh(ctx context.Context, in *api.RevokeRefreshReq, opts ...grpc.CallOption) (*api.RevokeRefreshResp, error) {
+	return nil, nil
+}
+func (m *MockDexAPIClient) VerifyPassword(ctx context.Context, in *api.VerifyPasswordReq, opts ...grpc.CallOption) (*api.VerifyPasswordResp, error) {
+	return nil, nil
+}
+func (m *MockDexAPIClient) CloseConnection() error {
+	return nil
+}
+
+var _ = Describe("Process DexClient CR", func() {
+	MyDexClientName := "dex-client-cluster1"
+	MyDexClientNamespace := "dex-client-cluster1-ns"
+	MyDexClientID := "dex-client-id1"
+	MyUpdatedDexClientID := "dex-client"
+	MyDexClientSecretName := "dex-client-secret1-name"
+	MyDexClientSecret := "dex-client-secret1"
+	MyDexClientSecretNamespace := "dex-client-secret1-ns"
+	MyRedirectURI := "https://oauth-openshift.testroutesubdomain1.testhost.com/oauth2callback/dex-client-id1"
+	const SECRET_MTLS_NAME = "grpc-mtls"
+	var dexClient *authv1alpha1.DexClient
+
+	It("should create a DexClient", func() {
+		By("creating a test namespace for the DexClient", func() {
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: MyDexClientNamespace,
+				},
+			}
+			err := k8sClient.Create(context.TODO(), ns)
+			Expect(err).To(BeNil())
+		})
+		By("creating a test namespace for the DexClient client secret", func() {
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: MyDexClientSecretNamespace,
+				},
+			}
+			err := k8sClient.Create(context.TODO(), ns)
+			Expect(err).To(BeNil())
+		})
+		By("creating a secret containing the dexclient's client secret", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      MyDexClientSecretName,
+					Namespace: MyDexClientSecretNamespace,
+				},
+				StringData: map[string]string{
+					"clientSecret": MyDexClientSecret,
+				},
+			}
+			err := k8sClient.Create(context.TODO(), secret)
+			Expect(err).To(BeNil())
+		})
+		By("creating the DexClient CR", func() {
+			// A DexClient object with metadata and spec.
+			dexClient = &authv1alpha1.DexClient{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      MyDexClientName,
+					Namespace: MyDexClientNamespace,
+				},
+				Spec: authv1alpha1.DexClientSpec{
+					ClientID: MyDexClientID,
+					ClientSecretRef: corev1.SecretReference{
+						Name:      MyDexClientSecretName,
+						Namespace: MyDexClientSecretNamespace,
+					},
+					RedirectURIs: []string{MyRedirectURI},
+				},
+			}
+			ctx := context.Background()
+			err := k8sClient.Create(ctx, dexClient)
+			Expect(err).To(BeNil())
+
+			createdDexClient := &authv1alpha1.DexClient{}
+
+			// Retry getting this newly created dexclient, given that creation may not immediately happen.
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: MyDexClientName, Namespace: MyDexClientNamespace}, createdDexClient)
+				return err == nil
+			}, 10, 1).Should(BeTrue())
+		})
+		By("running dex client reconcile", func() {
+			Eventually(func() bool {
+				req := ctrl.Request{}
+				req.Name = MyDexClientName
+				req.Namespace = MyDexClientNamespace
+				_, err := rDexClient.Reconcile(context.TODO(), req)
+				return err == nil
+			}, 10, 1).Should(BeTrue())
+		})
+	})
+	It("should update status condition in the DexClient if MTLS secret is not found", func() {
+		err := k8sClient.Get(ctx, client.ObjectKey{Name: MyDexClientName, Namespace: MyDexClientNamespace}, dexClient)
+		Expect(err).To(BeNil())
+		Expect(len(dexClient.Status.Conditions)).Should(BeNumerically(">", 0))
+		Expect(dexClient.Status.Conditions[0].Reason).To(Equal("MTLSSecretNotFound"))
+	})
+	It("should update status condition with GRPCConnectionFailed since dex server is not running", func() {
+		By("creating an MTLS secret", func() {
+			now := time.Now()
+			certDuration := time.Hour * 24
+			expiry := now.Add(certDuration)
+			labels := map[string]string{
+				"app": "dex-server-name",
+			}
+			annotations := map[string]string{
+				"auth.identitatem.io/expiry": expiry.UTC().Format(time.RFC3339),
+			}
+			secretSpec := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        SECRET_MTLS_NAME,
+					Namespace:   MyDexClientNamespace,
+					Labels:      labels,
+					Annotations: annotations,
+				},
+				Data: map[string][]byte{
+					"ca.crt":     []byte("ca.crt"),
+					"ca.key":     []byte("ca.key"),
+					"tls.crt":    []byte("tls.crt"),
+					"tls.key":    []byte("tls.key"),
+					"client.crt": []byte("client.crt"),
+					"client.key": []byte("client.key"),
+				},
+			}
+			err := k8sClient.Create(context.TODO(), secretSpec)
+			Expect(err).To(BeNil())
+		})
+		By("running reconcile", func() {
+			Eventually(func() bool {
+				req := ctrl.Request{}
+				req.Name = MyDexClientName
+				req.Namespace = MyDexClientNamespace
+				_, err := rDexClient.Reconcile(context.TODO(), req)
+				return err != nil // Reconcile will have an error
+			}, 10, 5).Should(BeTrue())
+		})
+		err := k8sClient.Get(ctx, client.ObjectKey{Name: MyDexClientName, Namespace: MyDexClientNamespace}, dexClient)
+		Expect(err).To(BeNil())
+		Expect(len(dexClient.Status.Conditions)).Should(BeNumerically(">", 0))
+		Expect(dexClient.Status.Conditions[0].Reason).To(Equal("GRPCConnectionFailed"))
+	})
+	It("should apply CR (status condition: Created) if dex api and grpc are mocked", func() {
+		By("mocking the dex api client and grpc connection", func() {
+			DexapiNewClientPEM = func(opts *dexapi.Options) (*dexapi.APIClient, error) {
+				// Mock dex API client
+				dexApiClient := new(MockDexAPIClient)
+				// Mock GRPC connection
+				conn, err := grpc.Dial("localhost:3000", grpc.WithInsecure())
+				Expect(err).To(BeNil())
+				return &dexapi.APIClient{
+					Dex: dexApiClient,
+					Cc:  conn,
+				}, nil
+			}
+		})
+		By("running reconcile", func() {
+			Eventually(func() bool {
+				req := ctrl.Request{}
+				req.Name = MyDexClientName
+				req.Namespace = MyDexClientNamespace
+				_, err := rDexClient.Reconcile(context.TODO(), req)
+				Expect(err).To(BeNil())
+				err = k8sClient.Get(ctx, client.ObjectKey{Name: MyDexClientName, Namespace: MyDexClientNamespace}, dexClient)
+				Expect(err).To(BeNil())
+				Expect(len(dexClient.Status.Conditions)).Should(BeNumerically(">", 0))
+				return dexClient.Status.Conditions[0].Reason == "Created"
+			}, 30, 1).Should(BeTrue())
+		})
+	})
+	It("should update the dex client", func() {
+		dexClient := &authv1alpha1.DexClient{}
+		By("retrieving the DexClient", func() {
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: MyDexClientName, Namespace: MyDexClientNamespace}, dexClient)
+			Expect(err).Should(BeNil())
+		})
+		By("updating the DexClient", func() {
+			dexClient.Spec.ClientID = MyUpdatedDexClientID
+			ctx := context.Background()
+			err := k8sClient.Update(ctx, dexClient)
+			Expect(err).To(BeNil())
+			// Retry getting this newly updated dexclient
+			updatedDexClient := &authv1alpha1.DexClient{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: MyDexClientName, Namespace: MyDexClientNamespace}, updatedDexClient)
+				return err == nil && updatedDexClient.Spec.ClientID == MyUpdatedDexClientID
+			}, 10, 1).Should(BeTrue())
+		})
+		By("running reconcile", func() {
+			Eventually(func() bool {
+				req := ctrl.Request{}
+				req.Name = MyDexClientName
+				req.Namespace = MyDexClientNamespace
+				_, err := rDexClient.Reconcile(context.TODO(), req)
+				Expect(err).To(BeNil())
+				err = k8sClient.Get(ctx, client.ObjectKey{Name: MyDexClientName, Namespace: MyDexClientNamespace}, dexClient)
+				Expect(err).To(BeNil())
+				return dexClient.Status.Conditions[0].Reason == "Updated"
+			}, 30, 1).Should(BeTrue())
+		})
+		By("Revert NewClientPEM", func() {
+			DexapiNewClientPEM = dexapi.NewClientPEM
+		})
+	})
+})

--- a/controllers/dexserver_controller_test.go
+++ b/controllers/dexserver_controller_test.go
@@ -1,0 +1,400 @@
+// Copyright Red Hat
+
+package controllers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ghodss/yaml"
+	dexoperatorconfig "github.com/identitatem/dex-operator/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	authv1alpha1 "github.com/identitatem/dex-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusteradmasset "open-cluster-management.io/clusteradm/pkg/helpers/asset"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var _ = Describe("Setup Dex", func() {
+	It("Check the CRDs availability", func() {
+		// This is to test if the CRD are available through resources.go
+		// as they are needed by other operators to dynamically install this operator
+		readerDex := dexoperatorconfig.GetScenarioResourcesReader()
+		_, err := getCRD(readerDex, "crd/bases/auth.identitatem.io_dexclients.yaml")
+		Expect(err).Should(BeNil())
+
+		_, err = getCRD(readerDex, "crd/bases/auth.identitatem.io_dexservers.yaml")
+		Expect(err).Should(BeNil())
+	})
+})
+
+var _ = Describe("Process DexServer CR", func() {
+	DexServerName := "my-dexserver"
+	DexServerNamespace := "my-dexserver-ns"
+	AuthRealmName := "my-authrealm"
+	AuthRealmNameSpace := "my-authrealm-ns"
+	MyGithubAppClientID := "my-github-app-client-id"
+	MyGithubAppClientSecretName := AuthRealmName + "github"
+	DexServerIssuer := "https://testroutesubdomain.testhost.com"
+	MyLDAPHost := "testldaphost:636"
+	MyLDAPBindDN := "fakebinddn"
+	MyLDAPBaseDN := "fakebasedn"
+	MyLDAPBindPW := "fakebindpw"
+	MyLDAPPWSecretName := AuthRealmName + "my-ldap-pw"
+	MyLDAPCertsSecretName := AuthRealmName + "my-ldap-certs"
+
+	var dexServer *authv1alpha1.DexServer
+	var configHashWithGitHub string
+	const SERVICE_ACCOUNT_NAME = "dex-operator-dexsso"
+
+	By("Creating a CR with a GitHub connector")
+	It("should create a DexServer", func() {
+		By("creating a test namespace for the DexServer", func() {
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DexServerNamespace,
+				},
+			}
+			err := k8sClient.Create(context.TODO(), ns)
+			Expect(err).To(BeNil())
+		})
+		By("creating a test namespace for the AuthRealm", func() {
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: AuthRealmNameSpace,
+				},
+			}
+			err := k8sClient.Create(context.TODO(), ns)
+			Expect(err).To(BeNil())
+		})
+		By("creating a secret containing the Github OAuth client secret", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      MyGithubAppClientSecretName,
+					Namespace: AuthRealmNameSpace,
+				},
+				StringData: map[string]string{
+					"clientSecret": "BogusSecret",
+				},
+			}
+			err := k8sClient.Create(context.TODO(), secret)
+			Expect(err).To(BeNil())
+		})
+		By("creating the DexServer CR", func() {
+			// A DexServer object with metadata and spec.
+			dexServer = &authv1alpha1.DexServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      DexServerName,
+					Namespace: DexServerNamespace,
+				},
+				Spec: authv1alpha1.DexServerSpec{
+					Issuer: DexServerIssuer,
+					Connectors: []authv1alpha1.ConnectorSpec{
+						{
+							Name: "my-github",
+							Id:   "my-github",
+							Type: "github",
+							GitHub: authv1alpha1.GitHubConfigSpec{
+								ClientID: MyGithubAppClientID,
+								ClientSecretRef: corev1.SecretReference{
+									Name:      MyGithubAppClientSecretName,
+									Namespace: AuthRealmNameSpace,
+								},
+							},
+						},
+					},
+				},
+			}
+			ctx := context.Background()
+			err := k8sClient.Create(ctx, dexServer)
+			Expect(err).To(BeNil())
+
+			createdDexServer := &authv1alpha1.DexServer{}
+
+			// Retry getting this newly created dexserver, given that creation may not immediately happen.
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, createdDexServer)
+				return err == nil
+			}, 10, 1).Should(BeTrue())
+		})
+		By("running reconcile", func() {
+			Eventually(func() bool {
+				req := ctrl.Request{}
+				req.Name = DexServerName
+				req.Namespace = DexServerNamespace
+				_, err := rDexServer.Reconcile(context.TODO(), req)
+				return err == nil
+			}, 10, 1).Should(BeTrue())
+		})
+	})
+	It("should set finalizer on the DexServer", func() {
+		dexServer := &authv1alpha1.DexServer{}
+		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dexServer)
+		Expect(controllerutil.ContainsFinalizer(dexServer, "auth.identitatem.io/cleanup")).To(BeTrue())
+		Expect(err).Should(BeNil())
+	})
+	It("should create a service account", func() {
+		serviceAccount := &corev1.ServiceAccount{}
+		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: SERVICE_ACCOUNT_NAME, Namespace: DexServerNamespace}, serviceAccount)
+		Expect(err).Should(BeNil())
+		Expect(serviceAccount.Labels["app"]).To(Equal(DexServerName))
+	})
+	It("should create http service for the dex server (with the default ingress certificate)", func() {
+		const SECRET_WEB_TLS_SUFFIX = "-tls-secret"
+		httpService := &corev1.Service{}
+		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, httpService)
+		Expect(err).Should(BeNil())
+		Expect(httpService).ShouldNot(BeNil())
+		Expect(httpService.Spec.Ports[0].Name).To(Equal("http"))
+		Expect(httpService.Spec.Ports[0].Port).To(Equal(int32(5556)))
+		Expect(httpService.ObjectMeta.Annotations["service.beta.openshift.io/serving-cert-secret-name"]).To(Equal(DexServerName + SECRET_WEB_TLS_SUFFIX))
+	})
+	It("should create grpc service for the dex server", func() {
+		const GRPC_SERVICE_NAME = "grpc"
+		grpcService := &corev1.Service{}
+		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: GRPC_SERVICE_NAME, Namespace: DexServerNamespace}, grpcService)
+		Expect(err).Should(BeNil())
+		Expect(grpcService).ShouldNot(BeNil())
+		Expect(grpcService.Spec.Ports[0].Name).To(Equal("grpc"))
+		Expect(grpcService.Spec.Ports[0].Port).To(Equal(int32(5557)))
+	})
+	It("should create ingress for the dex server", func() {
+		ingress := &v1beta1.Ingress{}
+		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, ingress)
+		Expect(err).Should(BeNil())
+		Expect(ingress).ShouldNot(BeNil())
+		By("Not specifying an Ingress Certificate ref in the dex server CR")
+		Expect(ingress.Spec.TLS).Should(BeNil())
+		By("Specifying an Ingress Certificate ref in the dex server CR")
+		// Get current dexserver
+		err = k8sClient.Get(ctx, client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dexServer)
+		Expect(err).Should(BeNil())
+		dexServer.Spec.IngressCertificateRef = corev1.LocalObjectReference{
+			Name: "customcert",
+		}
+		// Update dex server with Ingress cert ref
+		err = k8sClient.Update(ctx, dexServer)
+		Expect(err).To(BeNil())
+		// Retry getting the updated dexserver, given that the update may not immediately happen.
+		updatedDexServer := &authv1alpha1.DexServer{}
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, updatedDexServer)
+			Expect(err).To(BeNil())
+			return updatedDexServer.Spec.IngressCertificateRef.Name == "customcert"
+		}, 10, 1).Should(BeTrue())
+		By("running syncIngress again")
+		err = rDexServer.syncIngress(updatedDexServer, ctx)
+		Expect(err).Should(BeNil())
+		err = k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, ingress)
+		Expect(err).Should(BeNil())
+		Expect(ingress).ShouldNot(BeNil())
+		Expect(ingress.Spec.TLS[0].SecretName).To(Equal("customcert"))
+	})
+	It("should create ClusterRoleBinding", func() {
+		crb := &rbacv1.ClusterRoleBinding{}
+		clusterRoleBindingName := SERVICE_ACCOUNT_NAME + "-" + DexServerNamespace
+		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: clusterRoleBindingName}, crb)
+		Expect(err).Should(BeNil())
+		Expect(crb.RoleRef.Name).To(Equal(SERVICE_ACCOUNT_NAME))
+		Expect(len(crb.Subjects)).To(Equal(1))
+		Expect(crb.Subjects[0].Namespace).To(Equal(DexServerNamespace))
+	})
+	It("should create ConfigMap for dex", func() {
+		dexConfigMap := &corev1.ConfigMap{}
+		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dexConfigMap)
+		Expect(err).Should(BeNil())
+		Expect(dexConfigMap.Data["config.yaml"]).ShouldNot(BeNil())
+		configMapYamlString := dexConfigMap.Data["config.yaml"]
+		// Parse yaml
+		var configMapData map[string]interface{}
+		err = yaml.Unmarshal([]byte(configMapYamlString), &configMapData)
+		Expect(err).Should(BeNil())
+		// Verify the ConfigMap for GitHub
+		Expect(configMapData["issuer"]).To(Equal(DexServerIssuer))
+		connectors := configMapData["connectors"].([]interface{})
+		connector := connectors[0].(map[string]interface{})
+		Expect(connector["Type"]).To(Equal("github"))
+		connectorConfig := connector["Config"].(map[string]interface{})
+		Expect(connectorConfig["ClientID"]).To(Equal(MyGithubAppClientID))
+	})
+	It("should create Dex server deployment", func() {
+		dsDeployment := &appsv1.Deployment{}
+		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dsDeployment)
+		Expect(err).Should(BeNil())
+		By("using the dex image for the deployment", func() {
+			Expect(dsDeployment.Spec.Template.Spec.Containers[0].Image).To(Equal("dex_image"))
+		})
+		By("setting the configHash in the deployment", func() {
+			// Get ConfigMap
+			dexConfigMap := &corev1.ConfigMap{}
+			err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dexConfigMap)
+			Expect(err).Should(BeNil())
+			// Calculate hash
+			jsonData, err := json.Marshal(dexConfigMap)
+			Expect(err).Should(BeNil())
+			h := sha256.New()
+			h.Write([]byte(jsonData))
+			configHashWithGitHub = fmt.Sprintf("%x", h.Sum(nil))
+			Expect(dsDeployment.Spec.Template.ObjectMeta.Annotations["auth.identitatem.io/configHash"]).To(Equal(configHashWithGitHub))
+		})
+		By("setting the MTLS secret expiry timestamp in the deployment", func() {
+			// Check that the GRPC MTLS expiry is a valid time in the future
+			grpcMTlsExpiry := dsDeployment.Spec.Template.ObjectMeta.Annotations["auth.identitatem.io/grpcMtlsExpiry"]
+			Expect(grpcMTlsExpiry).ShouldNot(BeNil())
+			t, err := time.Parse(time.RFC3339, grpcMTlsExpiry)
+			Expect(err).Should(BeNil())
+			currentTime := time.Now()
+			Expect(t.After(currentTime)).To(BeTrue())
+		})
+	})
+	It("should process an updated DexServer CR with LDAP", func() {
+		dexServer := &authv1alpha1.DexServer{}
+		By("retrieving the DexServer", func() {
+			err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dexServer)
+			Expect(err).Should(BeNil())
+		})
+		By("creating a secret containing the bind password secret for LDAP", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      MyLDAPPWSecretName,
+					Namespace: AuthRealmNameSpace,
+				},
+				StringData: map[string]string{
+					"bindPW": MyLDAPBindPW,
+				},
+			}
+			err := k8sClient.Create(context.TODO(), secret)
+			Expect(err).To(BeNil())
+		})
+		By("creating a secret containing the root CA secret for LDAP", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      MyLDAPCertsSecretName,
+					Namespace: AuthRealmNameSpace,
+				},
+				Data: map[string][]byte{
+					"tls.crt": []byte("tls.mycrt"),
+					"tls.key": []byte("tls.mykey"),
+					"ca.crt":  []byte("ca.crt"),
+				},
+			}
+			err := k8sClient.Create(context.TODO(), secret)
+			Expect(err).To(BeNil())
+		})
+		By("adding an LDAP connector to the DexServer", func() {
+			dexServerConnectors := []authv1alpha1.ConnectorSpec{
+				{
+					Name: "my-github",
+					Id:   "my-github",
+					Type: "github",
+					GitHub: authv1alpha1.GitHubConfigSpec{
+						ClientID: MyGithubAppClientID,
+						ClientSecretRef: corev1.SecretReference{
+							Name:      MyGithubAppClientSecretName,
+							Namespace: AuthRealmNameSpace,
+						},
+					},
+				},
+				{
+					Name: "my-ldap",
+					Id:   "my-ldap",
+					Type: "ldap",
+					LDAP: authv1alpha1.LDAPConfigSpec{
+						Host:          MyLDAPHost,
+						InsecureNoSSL: false,
+						BindDN:        MyLDAPBindDN,
+						RootCARef: corev1.SecretReference{
+							Name:      MyLDAPCertsSecretName,
+							Namespace: AuthRealmNameSpace,
+						},
+						BindPWRef: corev1.SecretReference{
+							Name:      MyLDAPPWSecretName,
+							Namespace: AuthRealmNameSpace,
+						},
+						UsernamePrompt: "Email Address",
+						UserSearch: authv1alpha1.UserSearchSpec{
+							BaseDN:    MyLDAPBaseDN,
+							Filter:    "(objectClass=person)",
+							Username:  "userPrincipalName",
+							IDAttr:    "DN",
+							EmailAttr: "userPrincipalName",
+							NameAttr:  "cn",
+						},
+					},
+				},
+			}
+			dexServer.Spec.Connectors = dexServerConnectors
+
+			ctx := context.Background()
+			err := k8sClient.Update(ctx, dexServer)
+			Expect(err).To(BeNil())
+
+			updatedDexServer := &authv1alpha1.DexServer{}
+
+			// Retry getting this newly updated dexserver
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, updatedDexServer)
+				return err == nil && len(updatedDexServer.Spec.Connectors) == 2
+			}, 10, 1).Should(BeTrue())
+
+			By("running reconcile", func() {
+				Eventually(func() bool {
+					req := ctrl.Request{}
+					req.Name = DexServerName
+					req.Namespace = DexServerNamespace
+					_, err := rDexServer.Reconcile(context.TODO(), req)
+					return err == nil
+				}, 10, 1).Should(BeTrue())
+			})
+		})
+		By("Checking that the configMap is updated with the LDAP connector", func() {
+			dexConfigMap := &corev1.ConfigMap{}
+			err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dexConfigMap)
+			Expect(err).Should(BeNil())
+			Expect(dexConfigMap.Data["config.yaml"]).ShouldNot(BeNil())
+			configMapYamlString := dexConfigMap.Data["config.yaml"]
+			// Parse yaml
+			var configMapData map[string]interface{}
+			err = yaml.Unmarshal([]byte(configMapYamlString), &configMapData)
+			Expect(err).Should(BeNil())
+			// Verify the ConfigMap for LDAP
+			connectors := configMapData["connectors"].([]interface{})
+			Expect(len(connectors)).To(Equal(2)) // 2 connectors: Github, LDAP
+			connector := connectors[1].(map[string]interface{})
+			Expect(connector["Type"]).To(Equal("ldap"))
+			connectorConfig := connector["Config"].(map[string]interface{})
+			Expect(connectorConfig["BindDN"]).To(Equal(MyLDAPBindDN))
+			Expect(connectorConfig["rootCA"]).To(Equal("/etc/dex/ldapcerts/my-ldap/ca.crt"))
+		})
+		By("Checking that the configHash in the deployment is updated", func() {
+			dsDeployment := &appsv1.Deployment{}
+			err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dsDeployment)
+			Expect(err).Should(BeNil())
+			Expect(dsDeployment.Spec.Template.ObjectMeta.Annotations["auth.identitatem.io/configHash"]).ToNot(Equal(configHashWithGitHub))
+		})
+	})
+})
+
+func getCRD(reader *clusteradmasset.ScenarioResourcesReader, file string) (*apiextensionsv1.CustomResourceDefinition, error) {
+	b, err := reader.Asset(file)
+	if err != nil {
+		return nil, err
+	}
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := yaml.Unmarshal(b, crd); err != nil {
+		return nil, err
+	}
+	return crd, nil
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -4,38 +4,22 @@ package controllers
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	dexoperatorconfig "github.com/identitatem/dex-operator/config"
-
-	clusteradmasset "open-cluster-management.io/clusteradm/pkg/helpers/asset"
-
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	authv1alpha1 "github.com/identitatem/dex-operator/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -46,11 +30,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	ctx       context.Context
-	cancel    context.CancelFunc
-	r         DexServerReconciler
+	k8sClient  client.Client
+	testEnv    *envtest.Environment
+	ctx        context.Context
+	cancel     context.CancelFunc
+	rDexServer DexServerReconciler
+	rDexClient DexClientReconciler
 )
 
 func TestAPIs(t *testing.T) {
@@ -103,8 +88,8 @@ var _ = BeforeSuite(func(done Done) {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	By("Init the reconciler")
-	r = DexServerReconciler{
+	By("Init the reconcilers")
+	rDexServer = DexServerReconciler{
 		Client:             k8sClient,
 		KubeClient:         kubernetes.NewForConfigOrDie(cfg),
 		DynamicClient:      dynamic.NewForConfigOrDie(cfg),
@@ -112,7 +97,15 @@ var _ = BeforeSuite(func(done Done) {
 		Scheme:             scheme.Scheme,
 	}
 
-	err = (r).SetupWithManager(k8sManager)
+	err = (rDexServer).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	rDexClient = DexClientReconciler{
+		Client: k8sClient,
+		Scheme: scheme.Scheme,
+	}
+
+	err = (rDexClient).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {
@@ -130,375 +123,3 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
-
-var _ = Describe("Setup Dex", func() {
-	It("Check the CRDs availability", func() {
-		// This is to test if the CRD are available through resources.go
-		// as they are needed by other operators to dynamically install this operator
-		readerDex := dexoperatorconfig.GetScenarioResourcesReader()
-		_, err := getCRD(readerDex, "crd/bases/auth.identitatem.io_dexclients.yaml")
-		Expect(err).Should(BeNil())
-
-		_, err = getCRD(readerDex, "crd/bases/auth.identitatem.io_dexservers.yaml")
-		Expect(err).Should(BeNil())
-	})
-})
-
-var _ = Describe("Process DexServer CR", func() {
-	DexServerName := "my-dexserver"
-	DexServerNamespace := "my-dexserver-ns"
-	AuthRealmName := "my-authrealm"
-	AuthRealmNameSpace := "my-authrealm-ns"
-	MyGithubAppClientID := "my-github-app-client-id"
-	MyGithubAppClientSecretName := AuthRealmName + "github"
-	DexServerIssuer := "https://testroutesubdomain.testhost.com"
-	MyLDAPHost := "testldaphost:636"
-	MyLDAPBindDN := "fakebinddn"
-	MyLDAPBaseDN := "fakebasedn"
-	MyLDAPBindPW := "fakebindpw"
-	MyLDAPPWSecretName := AuthRealmName + "my-ldap-pw"
-	MyLDAPCertsSecretName := AuthRealmName + "my-ldap-certs"
-
-	var dexServer *authv1alpha1.DexServer
-	var configHashWithGitHub string
-	const SERVICE_ACCOUNT_NAME = "dex-operator-dexsso"
-
-	By("Creating a CR with a GitHub connector")
-	It("should create a DexServer", func() {
-		By("creating a test namespace for the DexServer", func() {
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: DexServerNamespace,
-				},
-			}
-			err := k8sClient.Create(context.TODO(), ns)
-			Expect(err).To(BeNil())
-		})
-		By("creating a test namespace for the AuthRealm", func() {
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: AuthRealmNameSpace,
-				},
-			}
-			err := k8sClient.Create(context.TODO(), ns)
-			Expect(err).To(BeNil())
-		})
-		By("creating a secret containing the Github OAuth client secret", func() {
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      MyGithubAppClientSecretName,
-					Namespace: AuthRealmNameSpace,
-				},
-				StringData: map[string]string{
-					"clientSecret": "BogusSecret",
-				},
-			}
-			err := k8sClient.Create(context.TODO(), secret)
-			Expect(err).To(BeNil())
-		})
-		By("creating the DexServer CR", func() {
-			// A DexServer object with metadata and spec.
-			dexServer = &authv1alpha1.DexServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      DexServerName,
-					Namespace: DexServerNamespace,
-				},
-				Spec: authv1alpha1.DexServerSpec{
-					Issuer: DexServerIssuer,
-					Connectors: []authv1alpha1.ConnectorSpec{
-						{
-							Name: "my-github",
-							Id:   "my-github",
-							Type: "github",
-							GitHub: authv1alpha1.GitHubConfigSpec{
-								ClientID: MyGithubAppClientID,
-								ClientSecretRef: corev1.SecretReference{
-									Name:      MyGithubAppClientSecretName,
-									Namespace: AuthRealmNameSpace,
-								},
-							},
-						},
-					},
-				},
-			}
-			ctx := context.Background()
-			err := k8sClient.Create(ctx, dexServer)
-			Expect(err).To(BeNil())
-
-			createdDexServer := &authv1alpha1.DexServer{}
-
-			// Retry getting this newly created dexserver, given that creation may not immediately happen.
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, createdDexServer)
-				return err == nil
-			}, 10, 1).Should(BeTrue())
-		})
-		By("running reconcile", func() {
-			Eventually(func() bool {
-				req := ctrl.Request{}
-				req.Name = DexServerName
-				req.Namespace = DexServerNamespace
-				_, err := r.Reconcile(context.TODO(), req)
-				return err == nil
-			}, 10, 1).Should(BeTrue())
-		})
-	})
-	It("should set finalizer on the DexServer", func() {
-		dexServer := &authv1alpha1.DexServer{}
-		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dexServer)
-		Expect(controllerutil.ContainsFinalizer(dexServer, "auth.identitatem.io/cleanup")).To(BeTrue())
-		Expect(err).Should(BeNil())
-	})
-	It("should create a service sccount", func() {
-		serviceAccount := &corev1.ServiceAccount{}
-		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: SERVICE_ACCOUNT_NAME, Namespace: DexServerNamespace}, serviceAccount)
-		Expect(err).Should(BeNil())
-		Expect(serviceAccount.Labels["app"]).To(Equal(DexServerName))
-	})
-	It("should create http service for the dex server (with the default ingress certificate)", func() {
-		const SECRET_WEB_TLS_SUFFIX = "-tls-secret"
-		httpService := &corev1.Service{}
-		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, httpService)
-		Expect(err).Should(BeNil())
-		Expect(httpService).ShouldNot(BeNil())
-		Expect(httpService.Spec.Ports[0].Name).To(Equal("http"))
-		Expect(httpService.Spec.Ports[0].Port).To(Equal(int32(5556)))
-		Expect(httpService.ObjectMeta.Annotations["service.beta.openshift.io/serving-cert-secret-name"]).To(Equal(DexServerName + SECRET_WEB_TLS_SUFFIX))
-	})
-	It("should create grpc service for the dex server", func() {
-		const GRPC_SERVICE_NAME = "grpc"
-		grpcService := &corev1.Service{}
-		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: GRPC_SERVICE_NAME, Namespace: DexServerNamespace}, grpcService)
-		Expect(err).Should(BeNil())
-		Expect(grpcService).ShouldNot(BeNil())
-		Expect(grpcService.Spec.Ports[0].Name).To(Equal("grpc"))
-		Expect(grpcService.Spec.Ports[0].Port).To(Equal(int32(5557)))
-	})
-	It("should create ingress for the dex server", func() {
-		ingress := &v1beta1.Ingress{}
-		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, ingress)
-		Expect(err).Should(BeNil())
-		Expect(ingress).ShouldNot(BeNil())
-		By("Not specifying an Ingress Certificate ref in the dex server CR")
-		Expect(ingress.Spec.TLS).Should(BeNil())
-		By("Specifying an Ingress Certificate ref in the dex server CR")
-		// Get current dexserver
-		err = k8sClient.Get(ctx, client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dexServer)
-		Expect(err).Should(BeNil())
-		dexServer.Spec.IngressCertificateRef = corev1.LocalObjectReference{
-			Name: "customcert",
-		}
-		// Update dex server with Ingress cert ref
-		err = k8sClient.Update(ctx, dexServer)
-		Expect(err).To(BeNil())
-		// Retry getting the updated dexserver, given that the update may not immediately happen.
-		updatedDexServer := &authv1alpha1.DexServer{}
-		Eventually(func() bool {
-			err := k8sClient.Get(ctx, client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, updatedDexServer)
-			Expect(err).To(BeNil())
-			return updatedDexServer.Spec.IngressCertificateRef.Name == "customcert"
-		}, 10, 1).Should(BeTrue())
-		By("running syncIngress again")
-		err = r.syncIngress(updatedDexServer, ctx)
-		Expect(err).Should(BeNil())
-		err = k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, ingress)
-		Expect(err).Should(BeNil())
-		Expect(ingress).ShouldNot(BeNil())
-		Expect(ingress.Spec.TLS[0].SecretName).To(Equal("customcert"))
-	})
-	It("should create ClusterRoleBinding", func() {
-		crb := &rbacv1.ClusterRoleBinding{}
-		clusterRoleBindingName := SERVICE_ACCOUNT_NAME + "-" + DexServerNamespace
-		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: clusterRoleBindingName}, crb)
-		Expect(err).Should(BeNil())
-		Expect(crb.RoleRef.Name).To(Equal(SERVICE_ACCOUNT_NAME))
-		Expect(len(crb.Subjects)).To(Equal(1))
-		Expect(crb.Subjects[0].Namespace).To(Equal(DexServerNamespace))
-	})
-	It("should create ConfigMap for dex", func() {
-		dexConfigMap := &corev1.ConfigMap{}
-		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dexConfigMap)
-		Expect(err).Should(BeNil())
-		Expect(dexConfigMap.Data["config.yaml"]).ShouldNot(BeNil())
-		configMapYamlString := dexConfigMap.Data["config.yaml"]
-		// Parse yaml
-		var configMapData map[string]interface{}
-		err = yaml.Unmarshal([]byte(configMapYamlString), &configMapData)
-		Expect(err).Should(BeNil())
-		// Verify the ConfigMap for GitHub
-		Expect(configMapData["issuer"]).To(Equal(DexServerIssuer))
-		connectors := configMapData["connectors"].([]interface{})
-		connector := connectors[0].(map[string]interface{})
-		Expect(connector["Type"]).To(Equal("github"))
-		connectorConfig := connector["Config"].(map[string]interface{})
-		Expect(connectorConfig["ClientID"]).To(Equal(MyGithubAppClientID))
-	})
-	It("should create Dex server deployment", func() {
-		dsDeployment := &appsv1.Deployment{}
-		err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dsDeployment)
-		Expect(err).Should(BeNil())
-		By("using the dex image for the deployment", func() {
-			Expect(dsDeployment.Spec.Template.Spec.Containers[0].Image).To(Equal("dex_image"))
-		})
-		By("setting the configHash in the deployment", func() {
-			// Get ConfigMap
-			dexConfigMap := &corev1.ConfigMap{}
-			err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dexConfigMap)
-			Expect(err).Should(BeNil())
-			// Calculate hash
-			jsonData, err := json.Marshal(dexConfigMap)
-			Expect(err).Should(BeNil())
-			h := sha256.New()
-			h.Write([]byte(jsonData))
-			configHashWithGitHub = fmt.Sprintf("%x", h.Sum(nil))
-			Expect(dsDeployment.Spec.Template.ObjectMeta.Annotations["auth.identitatem.io/configHash"]).To(Equal(configHashWithGitHub))
-		})
-		By("setting the MTLS secret expiry timestamp in the deployment", func() {
-			// Check that the GRPC MTLS expiry is a valid time in the future
-			grpcMTlsExpiry := dsDeployment.Spec.Template.ObjectMeta.Annotations["auth.identitatem.io/grpcMtlsExpiry"]
-			Expect(grpcMTlsExpiry).ShouldNot(BeNil())
-			t, err := time.Parse(time.RFC3339, grpcMTlsExpiry)
-			Expect(err).Should(BeNil())
-			currentTime := time.Now()
-			Expect(t.After(currentTime)).To(BeTrue())
-		})
-	})
-	It("should process an updated DexServer CR with LDAP", func() {
-		dexServer := &authv1alpha1.DexServer{}
-		By("retrieving the DexServer", func() {
-			err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dexServer)
-			Expect(err).Should(BeNil())
-		})
-		By("creating a secret containing the bind password secret for LDAP", func() {
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      MyLDAPPWSecretName,
-					Namespace: AuthRealmNameSpace,
-				},
-				StringData: map[string]string{
-					"bindPW": MyLDAPBindPW,
-				},
-			}
-			err := k8sClient.Create(context.TODO(), secret)
-			Expect(err).To(BeNil())
-		})
-		By("creating a secret containing the root CA secret for LDAP", func() {
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      MyLDAPCertsSecretName,
-					Namespace: AuthRealmNameSpace,
-				},
-				Data: map[string][]byte{
-					"tls.crt": []byte("tls.mycrt"),
-					"tls.key": []byte("tls.mykey"),
-					"ca.crt":  []byte("ca.crt"),
-				},
-			}
-			err := k8sClient.Create(context.TODO(), secret)
-			Expect(err).To(BeNil())
-		})
-		By("adding an LDAP connector to the DexServer", func() {
-			dexServerConnectors := []authv1alpha1.ConnectorSpec{
-				{
-					Name: "my-github",
-					Id:   "my-github",
-					Type: "github",
-					GitHub: authv1alpha1.GitHubConfigSpec{
-						ClientID: MyGithubAppClientID,
-						ClientSecretRef: corev1.SecretReference{
-							Name:      MyGithubAppClientSecretName,
-							Namespace: AuthRealmNameSpace,
-						},
-					},
-				},
-				{
-					Name: "my-ldap",
-					Id:   "my-ldap",
-					Type: "ldap",
-					LDAP: authv1alpha1.LDAPConfigSpec{
-						Host:          MyLDAPHost,
-						InsecureNoSSL: false,
-						BindDN:        MyLDAPBindDN,
-						RootCARef: corev1.SecretReference{
-							Name:      MyLDAPCertsSecretName,
-							Namespace: AuthRealmNameSpace,
-						},
-						BindPWRef: corev1.SecretReference{
-							Name:      MyLDAPPWSecretName,
-							Namespace: AuthRealmNameSpace,
-						},
-						UsernamePrompt: "Email Address",
-						UserSearch: authv1alpha1.UserSearchSpec{
-							BaseDN:    MyLDAPBaseDN,
-							Filter:    "(objectClass=person)",
-							Username:  "userPrincipalName",
-							IDAttr:    "DN",
-							EmailAttr: "userPrincipalName",
-							NameAttr:  "cn",
-						},
-					},
-				},
-			}
-			dexServer.Spec.Connectors = dexServerConnectors
-
-			ctx := context.Background()
-			err := k8sClient.Update(ctx, dexServer)
-			Expect(err).To(BeNil())
-
-			updatedDexServer := &authv1alpha1.DexServer{}
-
-			// Retry getting this newly updated dexserver
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, updatedDexServer)
-				return err == nil && len(updatedDexServer.Spec.Connectors) == 2
-			}, 10, 1).Should(BeTrue())
-
-			By("running reconcile", func() {
-				Eventually(func() bool {
-					req := ctrl.Request{}
-					req.Name = DexServerName
-					req.Namespace = DexServerNamespace
-					_, err := r.Reconcile(context.TODO(), req)
-					return err == nil
-				}, 10, 1).Should(BeTrue())
-			})
-		})
-		By("Checking that the configMap is updated with the LDAP connector", func() {
-			dexConfigMap := &corev1.ConfigMap{}
-			err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dexConfigMap)
-			Expect(err).Should(BeNil())
-			Expect(dexConfigMap.Data["config.yaml"]).ShouldNot(BeNil())
-			configMapYamlString := dexConfigMap.Data["config.yaml"]
-			// Parse yaml
-			var configMapData map[string]interface{}
-			err = yaml.Unmarshal([]byte(configMapYamlString), &configMapData)
-			Expect(err).Should(BeNil())
-			// Verify the ConfigMap for LDAP
-			connectors := configMapData["connectors"].([]interface{})
-			Expect(len(connectors)).To(Equal(2)) // 2 connectors: Github, LDAP
-			connector := connectors[1].(map[string]interface{})
-			Expect(connector["Type"]).To(Equal("ldap"))
-			connectorConfig := connector["Config"].(map[string]interface{})
-			Expect(connectorConfig["BindDN"]).To(Equal(MyLDAPBindDN))
-			Expect(connectorConfig["rootCA"]).To(Equal("/etc/dex/ldapcerts/my-ldap/ca.crt"))
-		})
-		By("Checking that the configHash in the deployment is updated", func() {
-			dsDeployment := &appsv1.Deployment{}
-			err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: DexServerName, Namespace: DexServerNamespace}, dsDeployment)
-			Expect(err).Should(BeNil())
-			Expect(dsDeployment.Spec.Template.ObjectMeta.Annotations["auth.identitatem.io/configHash"]).ToNot(Equal(configHashWithGitHub))
-		})
-	})
-})
-
-func getCRD(reader *clusteradmasset.ScenarioResourcesReader, file string) (*apiextensionsv1.CustomResourceDefinition, error) {
-	b, err := reader.Asset(file)
-	if err != nil {
-		return nil, err
-	}
-	crd := &apiextensionsv1.CustomResourceDefinition{}
-	if err := yaml.Unmarshal(b, crd); err != nil {
-		return nil, err
-	}
-	return crd, nil
-}


### PR DESCRIPTION
Zenhub issue: https://github.com/open-cluster-management/backlog/issues/17474

1. Split the dexserver and dexclient controller tests into separate files with the reconcilers initialized in suite_test.go.
2. Add tests for the dexclient controller (coverage ~66%)
3. Add a GitHub Actions workflow to trigger tests to run on a PR

Notes: 
- Export Dex and Cc within the API client in `controllers/dex/dex.go` to enable testing
- In `controllers/dexclient_controller.go` assign dexapi.NewClientPEM function to a package level variable to enable mocking 
