### PR TITLE
Use environment variables sourced from secrets for sensitive values in Dex ConfigMap

### DIFF
--- a/controllers/dexserver_controller.go
+++ b/controllers/dexserver_controller.go
@@ -776,7 +776,7 @@ func (r *DexServerReconciler) getEnvironmentVariableForSecret(ctx context.Contex
 	if err := r.Client.Get(context.TODO(), client.ObjectKey{Name: secretName, Namespace: dexServer.Namespace}, credentialSecret); err != nil {
 		// The environment variable will be added once the secret is created
 		if !kubeerrors.IsNotFound(err) {
-			log.Error(err, "error getting secret containing GitHub client secret")
+			log.Error(err, fmt.Sprintf("error getting secret containing credential for %s", connector.Type))
 			return newEnvVariable, err
 		}
 		return newEnvVariable, nil

--- a/controllers/dexserver_controller.go
+++ b/controllers/dexserver_controller.go
@@ -585,11 +585,6 @@ func (r *DexServerReconciler) syncDeployment(dexServer *authv1alpha1.DexServer, 
 		var secretName string
 		switch connector.Type {
 		case authv1alpha1.ConnectorTypeGitHub:
-			if err != nil {
-				log.Error(err, "Error getting client secret")
-				return err
-			}			
-
 			// To ensure uniqueness of names for secrets copied into the dex server namespace, the secret name is prefixed with the original namespace
 			secretName = connector.GitHub.ClientSecretRef.Namespace + "-" + connector.GitHub.ClientSecretRef.Name
 		case authv1alpha1.ConnectorTypeMicrosoft:
@@ -714,24 +709,24 @@ func (r *DexServerReconciler) syncDeployment(dexServer *authv1alpha1.DexServer, 
 	}
 
 	values := struct {
-		DexImage               string
-		DexConfigMapHash       string
-		RootCAHash             string
-		ConnectorCredentialsHash	string
-		ServiceAccountName     string
-		TlsSecretName          string
-		MtlsSecretName         string
-		MtlsSecretExpiry       string
-		DexServer              *authv1alpha1.DexServer
-		AdditionalEnvVariables string
-		AdditionalVolumeMounts string
-		AdditionalVolumes      string
+		DexImage                 string
+		DexConfigMapHash         string
+		RootCAHash               string
+		ConnectorCredentialsHash string
+		ServiceAccountName       string
+		TlsSecretName            string
+		MtlsSecretName           string
+		MtlsSecretExpiry         string
+		DexServer                *authv1alpha1.DexServer
+		AdditionalEnvVariables   string
+		AdditionalVolumeMounts   string
+		AdditionalVolumes        string
 	}{
-		DexImage:           dexImage,
-		DexConfigMapHash:   dexConfigMapHash,
-		RootCAHash:         rootCAHash,
+		DexImage:                 dexImage,
+		DexConfigMapHash:         dexConfigMapHash,
+		RootCAHash:               rootCAHash,
 		ConnectorCredentialsHash: connectorCredsHash,
-		ServiceAccountName: SERVICE_ACCOUNT_NAME,
+		ServiceAccountName:       SERVICE_ACCOUNT_NAME,
 		// this secret is generated using service serving certificate via service annotation
 		// service.beta.openshift.io/serving-cert-secret-name: dexServer.Name-tls-secret
 		TlsSecretName: fmt.Sprintf(dexServer.Name + SECRET_WEB_TLS_SUFFIX),

--- a/deploy/dex-server/deployment.yaml
+++ b/deploy/dex-server/deployment.yaml
@@ -59,6 +59,7 @@ spec:
         env:
         - name: KUBERNETES_POD_NAMESPACE
           value: "{{ .DexServer.Namespace }}"
+{{ .AdditionalEnvVariables | indent 8 }}
         image: "{{ .DexImage }}"
         imagePullPolicy: Always
         name: "{{ .DexServer.Name }}"

--- a/deploy/dex-server/deployment.yaml
+++ b/deploy/dex-server/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       {{ if .RootCAHash}}
         auth.identitatem.io/rootCAHash: "{{ .RootCAHash }}"
       {{ end }}
+      {{ if .ConnectorCredentialsHash}}
+        auth.identitatem.io/connectorCredentialsHash: "{{ .ConnectorCredentialsHash }}"
+      {{ end }}
       {{ if .DexConfigMapHash}}
         auth.identitatem.io/configHash: "{{ .DexConfigMapHash }}"
       {{ end }}


### PR DESCRIPTION
Zenhub issue: https://github.com/open-cluster-management/backlog/issues/18358

1. Copy credentials like GH client secret, Microsoft client secret and LDAP bind password from secrets in the user's namespace to secrets in the dexserver ns.
2. Use environment variables to reference these secrets and suffix the environment variable with an alphanumeric string derived from the connector's Id. This is needed to distinguish environment variables between multiple connectors of the same type.
3. Handle triggering new dexserver deployments when there are any updates to the original credential secrets for the connector.