### PR TITLE
remove go 1.16 ref since we are using 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # Copyright Red Hat
 
 # Build the manager binary
-#FROM golang:1.16 as builder
 FROM registry.ci.openshift.org/stolostron/builder:go1.17-linux AS builder
 
 


### PR DESCRIPTION
Signed-off-by: Chris Ahl <cahl@redhat.com>